### PR TITLE
Add cool "mousewheel to move" functionality

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -94,6 +94,13 @@ function love.keypressed(key, scancode, isrepeat)
 	if key == "f11"    then flipFullscreen() end
 end
 
+function love.mousemoved(x, y, dx, dy, istouch)
+	if love.mouse.isDown(3) and GM.state == "MainGame" then
+		Field.pos.x = Field.pos.x + dx / Field.zoom
+		Field.pos.y = Field.pos.y + dy / Field.zoom
+	end
+end
+
 function love.mousepressed(x, y, button, istouch)
 	if GM.state == "MainGame" and button == 1 then
 		Field.mousepressed()


### PR DESCRIPTION
## What?
With this you can hold your mousewheel while drugging the mouse to move the field without touching your keyboard.
## Why? 
Because right now we need a keyboard only for dragging the field around. You have to use both of your hands to play. By getting rid of keyboard, now I can drink tea with my first hand and play my favorite minesweeper game with my second hand.
I think its fine if we'll support both control variants